### PR TITLE
Small but visible change to the Swedish-translation

### DIFF
--- a/reddit_i18n/sv/LC_MESSAGES/r2.po
+++ b/reddit_i18n/sv/LC_MESSAGES/r2.po
@@ -2913,7 +2913,7 @@ msgstr ""
 #: r2/templates/printablebuttons.html:174
 #: r2/templates/subredditstylesheet.html:78
 msgid "save"
-msgstr "sparad"
+msgstr "spara"
 
 #: r2/templates/flairnextlink.html:25 r2/templates/listing.html:40
 #: r2/templates/tablelisting.html:52


### PR DESCRIPTION
Rättning av tempus för spara knappen. En synlig och välbehövd ändring. Finns den kanske där för att lura svenskar att delta i översättningsarbetet ;)

A well needed change for the translation of "save" into its present tense instead of it's preterite.
